### PR TITLE
Feature/yammer thread support

### DIFF
--- a/lib/backlog-streamer.rb
+++ b/lib/backlog-streamer.rb
@@ -27,8 +27,7 @@ module Backlog
           @last_updated = updates.last.updated_on
           updates.each do |u|
             notifier.notify(u, watchers(u))
-            puts "update found: #{u.type} #{u.summary}"
-            sleep 3
+            sleep 5
           end
         end
         sleep 10

--- a/lib/backlog-streamer/notifier.rb
+++ b/lib/backlog-streamer/notifier.rb
@@ -7,27 +7,16 @@ module Backlog
   class Notifier
 
     attr_reader :yammer
+
     def initialize(config)
       @yammer = Yammer.new(config)
       raise ArgumentError, "Specified group does not exist: #{config[:group]}" unless group(config[:group])
     end
 
     def notify(event, watchers)
+      return update(event, watchers) if event.type == '課題'
       origin = find_origin(event)
-      if origin
-        @yammer.update(format(event, watchers), :group_id => group.id, :replied_to_id => origin.id)
-        puts "update found(threaded): #{u.type} #{u.summary}"
-      else
-        @yammer.update(format(event, watchers), :group_id => group.id)
-        puts "update found(new): #{u.type} #{u.summary}"
-      end
-    end
-
-    def find_origin(event)
-      res = @yammer.search("#{event.key}: #{event.summary}")
-      puts "#{event.key}: #{event.summary}"
-      return nil if res['count'].messages == 0
-      res.messages.messages.select {|m| m.group_id == group.id }.sort_by {|m| m.created_at }.first
+      origin.nil? ? update(event, watchers) : update_with_thread(event, watchers, origin)
     end
 
     private
@@ -36,8 +25,14 @@ module Backlog
       @group ||= @yammer.groups(:letter => group).find {|g| g.name == group}
     end
 
-    def format(event, watchers)
-      (<<-MSG).gsub(/^ +/, '')
+    def find_origin(event)
+      res = @yammer.search("#{event.key}: #{event.summary}")
+      return nil if res['count'].messages == 0
+      res.messages.messages.select {|m| m.group_id == group.id }.sort_by {|m| m.created_at }.first
+    end
+
+    def update(event, watchers)
+      @yammer.update((<<-MSG).gsub(/^ +/, ''), :group_id => group.id)
         #{event.user}によって"#{event.key}: #{event.summary}"が#{event.type}されました。
         https://#{event.space}.backlog.jp/view/#{event.key}
 
@@ -45,8 +40,19 @@ module Backlog
 
         #{"cc: %s" % watchers.map {|w| "@#{w}" }.join(',') unless watchers.empty?}
       MSG
+      puts "update found(new): #{event.type} #{event.summary}"
     end
 
+    def update_with_thread(event, watchers, origin)
+        @yammer.update((<<-MSG).gsub(/^ +/, ''), :group_id => group.id, :replied_to_id => origin.id)
+          #{event.user}によって#{event.type}されました。
+
+          #{event.content}
+
+          #{"cc: %s" % watchers.map {|w| "@#{w}" }.join(',') unless watchers.empty?}
+        MSG
+        puts "update found(threaded): #{event.type} #{event.summary}"
+    end
   end
 end
 


### PR DESCRIPTION
Yammerの指定グループ上の投稿から"課題キー:  概要"で検索をして既に投稿があった場合は、検索結果から一番古い投稿に対してスレッド投稿をするようにした。

ついでに更新種別が"課題"の場合は新規課題なので、この場合は無条件に投稿するように。
